### PR TITLE
Add template example back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,25 @@ aws_ssm_parameter_store 'getParametersbypath' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
 end
+
+template '/tmp/file_with_data.txt' do
+  source 'file_with_data.txt.erb'
+  owner 'ec2-user'
+  group 'ec2-user'
+  mode '0755'
+  sensitive true
+  variables lazy {
+    {
+       clear_value: node.run_state['clear_value'],
+       decrypted_custom_value: node.run_state['decrypted_custom_value'],
+       decrypted_value: node.run_state['decrypted_value'],
+       path1_value: node.run_state['path_values']['/pathtest/path1'],
+       path2_value: node.run_state['path_values']['/pathtest/path2'],
+       parm1_value: node.run_state['parameter_values']['/testkitchen/ClearTextString'],
+       parm2_value: node.run_state['parameter_values']['/testkitchen'],
+    }
+  }
+end
 ```
 
 ##### Get bucket name and retrieve file


### PR DESCRIPTION
### Description

This was removed in 337c45a8a4d4d35d64728ef6a47abd0fb9186148, but the commit does not explain why. The PR seems to suggest a change in nested hashes, but does that change accessing behaviour in run_state or make the template incorrect?

When coming to use this resource, I wasn't aware of the `lazy` evaluation (I guess I don't know Chef as well I could), and spent some time figuring out how to put values into a template. I only found this
example had been removed after I'd figured it out.

I don't think it hurts to have the example in the README. If it's now incorrect, can we amend it instead of completely removing it? 

### Issues Resolved

Missing example

### Check List
N/A

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
