### PR TITLE
Fix ignored Route53 geolocation value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+- Route53 record: `geo_location_subdivision` attribute no longer ignored.
+- Route53 record: `geo_location` attribute type changed to `Hash`.
+
 ## 8.4.0 - *2021-01-24*
 
 - Sous Chefs Adoption

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -114,12 +114,12 @@ action_class do
   end
 
   def geo_location
-    if geo_location_country
+    if geo_location_country && geo_location_subdivision
+      { country_code: geo_location_country, subdivision_code: geo_location_subdivision }
+    elsif geo_location_country
       { country_code: geo_location_country }
     elsif geo_location_continent
       { continent_code: geo_location_continent }
-    elsif geo_location_subdivision
-      { country_code: geo_location_country, subdivision_code: geo_location_subdivision }
     else
       @geo_location ||= new_resource.geo_location
     end

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -8,7 +8,7 @@ property :ttl,                         Integer, default: 3600
 property :weight,                      String
 property :record_name,                 String
 property :set_identifier,              String
-property :geo_location,                String
+property :geo_location,                Hash
 property :geo_location_country,        String
 property :geo_location_continent,      String
 property :geo_location_subdivision,    String


### PR DESCRIPTION
# Description

If `geo_location_country` is specified, `geo_location_subdivision` will **always be ignored**. And you need to specify both arguments. Our use case is to replicate this `Change` to make a geolocation rule for Crimea:

```
<Change>
  <Action>CREATE</Action>
  <ResourceRecordSet>
    <Name>verysupercool.lookatme.example.com</Name>
    <Type>A</Type>
    <SetIdentifier>test</SetIdentifier>
    <GeoLocation>
      <CountryCode>UA</CountryCode>
      <SubdivisionCode>11</SubdivisionCode>
    </GeoLocation>
    <TTL>300</TTL>
    <ResourceRecords>
      <ResourceRecord>
        <Value>127.0.0.1</Value>
      </ResourceRecord>
    </ResourceRecords>
  </ResourceRecordSet>
</Change>
```

## Issues Resolved

`#geo_location` no longer ignores `geo_location_subdivision`

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
