### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file is used to list changes made in each version of the aws cookbook.
 - resolved cookstyle error: resources/security_group.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - resolved cookstyle error: resources/ssm_parameter_store.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - resolved cookstyle error: test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb:93:7 convention: `Layout/LeadingCommentSpace`
+- Require Chef 15.3+ for unified mode
+- Require unified_mode for Chef 17+ support
+
 ## 8.4.1 - *2021-08-26*
 
 ## 8.4.0 - *2021-01-24*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/route53_record.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/security_group.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/ssm_parameter_store.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb:93:7 convention: `Layout/LeadingCommentSpace`
 ## 8.4.1 - *2021-08-26*
 
 ## 8.4.0 - *2021-01-24*

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ end
 
 source_url 'https://github.com/chef-cookbooks/aws'
 issues_url 'https://github.com/chef-cookbooks/aws/issues'
-chef_version '>= 12.15'
+chef_version '>= 15.3'
 
 # Pin the aws sdk to the minor version to only pull
 # in new patches by default. For some of these

--- a/resources/autoscaling.rb
+++ b/resources/autoscaling.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :return_info, [String, Array]
 property :should_decrement_desired_capacity, [true, false], default: true
 property :asg_name, String

--- a/resources/cloudformation_stack.rb
+++ b/resources/cloudformation_stack.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :stack_name, String, name_property: true
 # location of the template body, located in the "files" cookbook dir
 property :template_source, String, required: true

--- a/resources/cloudwatch.rb
+++ b/resources/cloudwatch.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :alarm_name, String, name_property: true
 property :alarm_description, String
 property :actions_enabled, true

--- a/resources/dynamodb_table.rb
+++ b/resources/dynamodb_table.rb
@@ -1,4 +1,5 @@
 default_action :create
+unified_mode true
 
 attribute :table_name, kind_of: String, name_attribute: true
 attribute :attribute_definitions, kind_of: Array, required: true

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :region,                String, default: lazy { fallback_region }
 property :size,                  Integer
 property :snapshot_id,           String

--- a/resources/elastic_ip.rb
+++ b/resources/elastic_ip.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :ip,                    String, name_property: true
 property :timeout,               [Integer, nil], default: 3 * 60 # 3 mins, nil or 0 for no timeout
 

--- a/resources/elastic_lb.rb
+++ b/resources/elastic_lb.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :listeners,             Array
 property :security_groups,       Array
 property :subnets,               Array # for VPC networking

--- a/resources/iam_group.rb
+++ b/resources/iam_group.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :group_name, String, name_property: true
 property :path, String, default: '/'
 property :members, Array, default: []

--- a/resources/iam_policy.rb
+++ b/resources/iam_policy.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :policy_name, String, name_property: true
 property :path, String, default: '/'
 property :policy_document, String, required: true

--- a/resources/iam_role.rb
+++ b/resources/iam_role.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :role_name, String, name_property: true
 property :path, String, default: '/'
 property :assume_role_policy_document, String, required: true

--- a/resources/iam_user.rb
+++ b/resources/iam_user.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :user_name, String, name_property: true
 property :path, String, default: '/'
 property :region, String, default: lazy { fallback_region }

--- a/resources/instance_monitoring.rb
+++ b/resources/instance_monitoring.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :aws_access_key, String
 property :aws_secret_access_key, String, sensitive: true
 property :aws_session_token, String, sensitive: true

--- a/resources/instance_role.rb
+++ b/resources/instance_role.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :aws_access_key, String
 property :aws_secret_access_key, String, sensitive: true
 property :aws_session_token, String, sensitive: true

--- a/resources/instance_term_protection.rb
+++ b/resources/instance_term_protection.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :aws_access_key, String
 property :aws_secret_access_key, String, sensitive: true
 property :aws_session_token, String, sensitive: true

--- a/resources/kinesis_stream.rb
+++ b/resources/kinesis_stream.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :stream_name, String, name_property: true
 property :starting_shard_count, Integer, required: true
 property :region, String, default: lazy { fallback_region }

--- a/resources/resource_tag.rb
+++ b/resources/resource_tag.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :resource_id,           [String, Array], regex: /(i|snap|vol)-[a-fA-F0-9]{8}/, name_property: true
 property :tags,                  Hash, required: true
 

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -1,5 +1,6 @@
 resource_name :aws_route53_record
 provides :aws_route53_record
+unified_mode true
 provides :route53_record # for compatibility with the old cookbook
 
 property :value,                       [String, Array]

--- a/resources/route53_zone.rb
+++ b/resources/route53_zone.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :description, String
 property :private, [true, false], default: false
 property :vpc_id, String

--- a/resources/s3_bucket.rb
+++ b/resources/s3_bucket.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :region, String, default: lazy { fallback_region }
 property :delete_all_objects, [true, false], default: false
 property :versioning, [true, false], default: false, desired_state: false

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :path, String, name_property: true
 property :remote_path, String
 property :region, String, default: lazy { fallback_region }

--- a/resources/secondary_ip.rb
+++ b/resources/secondary_ip.rb
@@ -1,3 +1,4 @@
+unified_mode true
 property :ip,                    String, required: true
 property :interface,             String, default: lazy { node['network']['default_interface'] }
 property :timeout,               [Integer, nil], default: 3 * 60 # 3 mins, nil or 0 for no timeout

--- a/resources/security_group.rb
+++ b/resources/security_group.rb
@@ -10,6 +10,7 @@
 
 resource_name :aws_security_group
 provides :aws_security_group
+unified_mode true
 
 provides :security_group # legacy name
 

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -5,6 +5,7 @@
 
 resource_name :aws_ssm_parameter_store
 provides :ssm_parameter_store
+unified_mode true
 provides :aws_ssm_parameter_store
 
 # => Define the Resource Properties

--- a/test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb
@@ -90,7 +90,7 @@ file '/tmp/ssm_parameters.json' do
   content lazy {
     Chef::JSONCompat.to_json_pretty(
       clear_value: node.run_state['clear_value'],
-      #:decrypted_custom_value => node.run_state['decrypted_custom_value'],
+      # :decrypted_custom_value => node.run_state['decrypted_custom_value'],
       decrypted_value: node.run_state['decrypted_value'],
       path_values: node.run_state['path_values'],
       parameter_values: node.run_state['parameter_values'],


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.22.3 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/route53_record.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/security_group.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/ssm_parameter_store.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb

 - 93:7 convention: `Layout/LeadingCommentSpace` - Missing space after `#`. (https://rubystyle.guide#hash-space)