### PR TITLE
Add support for `fallback_region` in local zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+- Fixed a logic bug when relying on ec2 `fallback_region` from a local zone. Local zones have weird AZ names.
+
 ## 9.0.0 - *2021-09-01*
 
 - resolved cookstyle error: resources/route53_record.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -56,7 +56,11 @@ module AwsCookbook
       # facilitate support for region in resource name
       if node.attribute?('ec2')
         Chef::Log.debug("Using region #{node['ec2']['placement_availability_zone'].chop} from Ohai attributes")
-        node['ec2']['placement_availability_zone'].chop
+        if node['ec2']['placement_availability_zone'].split('-') > 3
+          node['ec2']['placement_availability_zone'].split('-')[0..2].join('-')
+        else
+          node['ec2']['placement_availability_zone'].chop
+        end
       else
         Chef::Log.debug('Falling back to region us-east-1 as Ohai data and resource defined region not present')
         'us-east-1'


### PR DESCRIPTION
# Description

This change allows you to use the ec2 `fallback_region` from within an AWS Local Zone.

## Issues Resolved

There is an issue currently when chopping off the AZ marker when in a local zone.

In the LAX localzone, your AZ is `us-west-2-lax-1a` instead of `us-west-2a` and post chop, it attempts to communicate with `<service>.us-west-2-lax-1.amazonaws.com` and fails.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.


My ruby knowledge is surface level, please let me know if my implementation is not proper ruby style.