### PR TITLE
Fix array length comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+- Fixed array length comparison in ec2 `fallback_region` function
+
 ## 9.0.1 - *2021-11-04*
 
 - Fixed a logic bug when relying on ec2 `fallback_region` from a local zone. Local zones have weird AZ names.

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -56,7 +56,7 @@ module AwsCookbook
       # facilitate support for region in resource name
       if node.attribute?('ec2')
         Chef::Log.debug("Using region #{node['ec2']['placement_availability_zone'].chop} from Ohai attributes")
-        if node['ec2']['placement_availability_zone'].split('-') > 3
+        if node['ec2']['placement_availability_zone'].split('-').count > 3
           node['ec2']['placement_availability_zone'].split('-')[0..2].join('-')
         else
           node['ec2']['placement_availability_zone'].chop


### PR DESCRIPTION
# Description

Fixes broken array length comparison introduced in https://github.com/sous-chefs/aws/pull/443

https://github.com/sous-chefs/aws/blob/be61ac22d8fc2f69aa917b1815fd76b3283f3ab3/libraries/ec2.rb#L59

```
[2021-11-04T14:57:41+00:00] FATAL: NoMethodError: undefined method `>' for ["us", "east", "1b"]:Array
```

## Issues Resolved

#444 

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
