### PR TITLE
Allow group and owner attributes of s3_file to be String or Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+Allow group attribute of s3_file to be String or Integer
+
 ## 9.0.16 - *2023-07-10*
 
 ## 9.0.15 - *2023-05-17*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Update checkout to v3 in ci.yml
 
 ## 8.3.1 (2020-12-04)
 
-- Resolve cookstyle warnings - [@cookstyle](https://github.com/cookstyle)
+- Resolve cookstyle warnings - [@cookstyle](https://github.com/chef/cookstyle)
 - Update AWS S3 gem dependency - [@arothian](https://github.com/arothian)
 
 ## 8.3.0 (2020-08-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
-Allow group attribute of s3_file to be String or Integer
+Allow attributes group and owner of s3_file to be String or Integer
 
 ## 9.0.16 - *2023-07-10*
 

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -4,7 +4,7 @@ property :remote_path, String
 property :region, String, default: lazy { fallback_region }
 property :bucket, String
 property :requester_pays, [true, false], default: false
-property :owner, String, regex: Chef::Config[:user_valid_regex]
+property :owner, [String, Integer], regex: Chef::Config[:user_valid_regex]
 property :group, [String, Integer], regex: Chef::Config[:group_valid_regex]
 property :mode, [String, nil]
 property :checksum, [String, nil]

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -5,7 +5,7 @@ property :region, String, default: lazy { fallback_region }
 property :bucket, String
 property :requester_pays, [true, false], default: false
 property :owner, String, regex: Chef::Config[:user_valid_regex]
-property :group, String, regex: Chef::Config[:group_valid_regex]
+property :group, [String, Integer], regex: Chef::Config[:group_valid_regex]
 property :mode, [String, nil]
 property :checksum, [String, nil]
 property :backup, [Integer, false], default: 5

--- a/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
@@ -50,3 +50,29 @@ aws_s3_file '/tmp/a_file_2' do
   aws_session_token node['aws_test']['session_token']
   region 'us-west-2'
 end
+
+# create group to test if group property works
+group 'testgroup' do
+  gid 4711
+  action :create
+end
+
+# create a s3_file with a group specified by its name
+aws_s3_file '/tmp/file_with_group_by_name' do
+  bucket node['aws_test']['bucket']
+  remote_path node['aws_test']['s3key']
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  aws_session_token node['aws_test']['session_token']
+  group 'testgroup'
+end
+
+# create a s3_file with a group specified by its gid
+aws_s3_file '/tmp/file_with_group_by_gid' do
+  bucket node['aws_test']['bucket']
+  remote_path node['aws_test']['s3key']
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  aws_session_token node['aws_test']['session_token']
+  group 4712
+end

--- a/test/integration/s3_file/default_spec.rb
+++ b/test/integration/s3_file/default_spec.rb
@@ -9,3 +9,12 @@ end
 describe file('/tmp/a_file') do
   it { should be_file }
 end
+
+describe file('/tmp/file_with_group_by_name') do
+  it { should be_file }
+  its('group') { should eq 'testgroup' }
+end
+
+describe file('/tmp/file_with_group_by_gid') do
+  it { should be_file }
+end


### PR DESCRIPTION
# Description

As the resource remote_file allows type String or Integer for the group and owner attribute, s3_file should do the same. (https://docs.chef.io/resources/remote_file/)

## Issues Resolved

No related issue

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
