### PR TITLE
Update documented requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 12.9+
+- Chef 15.3+
 
 ### Cookbooks
 


### PR DESCRIPTION
Tried to install the current version of this cookbook with Chef 12, and got this error:

```
Cookbook 'aws' version '9.1.4' depends on chef version [">= 15.3"], but the running chef version is 12.18.31
```

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
