### PR TITLE
Cloudwatch treat missing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the aws cookbook.
 
 ## Unreleased
 
+Allow usage of "treat_missing_data" option when creating/updating Cloudwatch alarms.
+
 ## 9.1.4 - *2023-12-27*
 
 ## 9.1.3 - *2023-10-31*

--- a/resources/cloudwatch.rb
+++ b/resources/cloudwatch.rb
@@ -16,6 +16,7 @@ property :unit, String
 property :evaluation_periods, Integer
 property :threshold, [Float, Integer]
 property :comparison_operator, String, equal_to: %w(GreaterThanOrEqualToThreshold GreaterThanThreshold LessThanThreshold LessThanOrEqualToThreshold)
+property :treat_missing_data, String, default: 'missing', equal_to: %w(breaching notBreaching ignore missing)
 
 # authentication
 property :region, String, default: lazy { fallback_region }
@@ -106,6 +107,7 @@ action_class do
     options[:dimensions] = new_resource.dimensions if new_resource.dimensions
     options[:extended_statistic] = new_resource.extended_statistic if new_resource.extended_statistic
     options[:unit] = new_resource.unit if new_resource.unit
+    options[:treat_missing_data] = new_resource.treat_missing_data if new_resource.treat_missing_data
     options
   end
 


### PR DESCRIPTION
# Description

Allow usage of "treat_missing_data" option when creating/updating Cloudwatch alarms.

## Issues Resolved

https://github.com/sous-chefs/aws/issues/484

## Check List
